### PR TITLE
(feature) PlayingContainer, EndGameContainer, minor server fix

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import FrontContainer from './containers/FrontContainer.jsx';
 
+import styles from './styles.css';
+
 export default class App extends Component {
   render() {
     return (

--- a/client/containers/EndGameContainer.jsx
+++ b/client/containers/EndGameContainer.jsx
@@ -1,8 +1,20 @@
 import React, { Component } from 'react';
 
 const EndGameContainer = (props) => {
+  let winner;
+  if (props.p1Score[props.p1Score.length-1] > props.p2Score[props.p2Score.length-1]) {
+    winner = props.p1name;
+  } else {
+    winner = props.p2name;
+  }
+
   return (
-    <div></div>
+    <div id="endgame-wrapper">
+      <p id="winner">{winner} Wins!</p>
+      <button id="rematch" onClick={props.handleEndGame}>Rematch</button>
+      <button id="winner-stay" onClick={props.handleEndGame}>Winner Stays</button>
+      <button id="both-leave" onClick={props.handleEndGame}>Both Leave</button>
+    </div>
   );
 }
 

--- a/client/containers/FrontContainer.jsx
+++ b/client/containers/FrontContainer.jsx
@@ -14,7 +14,7 @@ class FrontContainer extends Component {
       gameState: 0,
       p1Score: [0],
       p2Score: [0],
-      serving: 1,
+      serving: [],
       maxScore: 21,
       endGameChoice: null,
     }
@@ -24,6 +24,7 @@ class FrontContainer extends Component {
     this.setMaxScore = this.setMaxScore.bind(this);
     this.setServing = this.setServing.bind(this);
     this.handleScoreButton = this.handleScoreButton.bind(this);
+    this.handleEndGame = this.handleEndGame.bind(this);
   }
   
   componentDidMount() {
@@ -104,6 +105,27 @@ class FrontContainer extends Component {
     .catch(err=>console.error(err));
   }
 
+  handleEndGame(e) {
+    const body = {action: 'RESTART'};
+    switch(e.target.id) {
+      case 'rematch':
+        body.payload = 2;
+        break;
+      case 'winner-stay':
+        body.payload = 1;
+        break;
+      case 'both-leave':
+        body.payload = 0;
+        break;
+    }
+
+    axios.post('/action', body)
+    .then(res=>{
+      this.setState(res.data);
+    })
+    .catch(err=>console.error(err));
+  }
+
   render() {
     switch (this.state.gameState) {
       case 0:
@@ -120,15 +142,21 @@ class FrontContainer extends Component {
           />) ;
       case 1:
        return (<PlayingContainer
-        p1name={this.state.p1name}
-        p2name={this.state.p2name}
-        serving={this.state.serving}
-        p1Score={this.state.p1Score}
-        p2Score={this.state.p2Score}
-        handleScoreButton={this.handleScoreButton}
+          p1name={this.state.p1name}
+          p2name={this.state.p2name}
+          serving={this.state.serving}
+          p1Score={this.state.p1Score}
+          p2Score={this.state.p2Score}
+          handleScoreButton={this.handleScoreButton}
          />);
       case 2:
-        return (<EndGameContainer />);
+        return (<EndGameContainer
+          p1name={this.state.p1name}
+          p2name={this.state.p2name}
+          p1Score={this.state.p1Score}
+          p2Score={this.state.p2Score}
+          handleEndGame={this.handleEndGame}
+        />);
       default:
         return null;
     }

--- a/client/containers/FrontContainer.jsx
+++ b/client/containers/FrontContainer.jsx
@@ -12,8 +12,8 @@ class FrontContainer extends Component {
       p1name: 'Michael',
       p2name: 'Augustine',
       gameState: 0,
-      p1score: 0,
-      p2score: 0,
+      p1Score: [0],
+      p2Score: [0],
       serving: 1,
       maxScore: 21,
       endGameChoice: null,
@@ -23,6 +23,15 @@ class FrontContainer extends Component {
     this.startMatch = this.startMatch.bind(this);
     this.setMaxScore = this.setMaxScore.bind(this);
     this.setServing = this.setServing.bind(this);
+    this.handleScoreButton = this.handleScoreButton.bind(this);
+  }
+  
+  componentDidMount() {
+    axios.post('/action', {action: 'GET_STATE'})
+    .then(res=>{
+      this.setState(res.data);
+    })
+    .catch(err=>console.error(err));
   }
 
   setP1Name(e) {
@@ -72,8 +81,23 @@ class FrontContainer extends Component {
     .catch(err=>console.error(err));
   }
 
-  componentDidMount() {
-    axios.post('/action', {action: 'GET_STATE'})
+  handleScoreButton(e) {
+    const body = {};
+    switch(e.target.id) {
+      case 'inc-p1':
+        body.action = 'INCREMENT';
+        body.payload = {player: 1};
+        break;
+      case 'inc-p2':
+        body.action = 'INCREMENT';
+        body.payload = {player: 2};
+        break;
+      case 'undo':
+        body.action = 'UNDO';
+        break;
+    }
+
+    axios.post('/action', body)
     .then(res=>{
       this.setState(res.data);
     })
@@ -95,7 +119,14 @@ class FrontContainer extends Component {
           setServing={this.setServing}
           />) ;
       case 1:
-       return (<PlayingContainer />);
+       return (<PlayingContainer
+        p1name={this.state.p1name}
+        p2name={this.state.p2name}
+        serving={this.state.serving}
+        p1Score={this.state.p1Score}
+        p2Score={this.state.p2Score}
+        handleScoreButton={this.handleScoreButton}
+         />);
       case 2:
         return (<EndGameContainer />);
       default:

--- a/client/containers/PlayingContainer.jsx
+++ b/client/containers/PlayingContainer.jsx
@@ -9,7 +9,7 @@ const PlayingContainer = (props) => {
         <p id="colon">:</p>
         <p id="p2score">{props.p2Score[props.p2Score.length-1]}</p>
 
-        <p id={`serve${props.serving}`}>&#8595;</p>
+        <p id={`serve${props.serving[props.serving.length-1]}`}>&#8595;</p>
 
         <p id="p1-display-name">{props.p1name}</p>
         <p id="p2-display-name">{props.p2name}</p>

--- a/client/containers/PlayingContainer.jsx
+++ b/client/containers/PlayingContainer.jsx
@@ -2,6 +2,28 @@ import React, { Component } from 'react';
 
 const PlayingContainer = (props) => {
 
+  return (
+    <div>
+      <div id="score-wrapper">
+        <p id="p1score">{props.p1Score[props.p1Score.length-1]}</p>
+        <p id="colon">:</p>
+        <p id="p2score">{props.p2Score[props.p2Score.length-1]}</p>
+
+        <p id={`serve${props.serving}`}>&#8595;</p>
+
+        <p id="p1-display-name">{props.p1name}</p>
+        <p id="p2-display-name">{props.p2name}</p>
+      </div>
+      <div id="graph-wrapper">
+
+      </div>
+      <div id="button-wrapper">
+        <button id="inc-p1" onClick={props.handleScoreButton}>+</button>
+        <button id="inc-p2" onClick={props.handleScoreButton}>+</button>
+        <button id="undo" onClick={props.handleScoreButton}>Undo</button>
+      </div>
+    </div>
+  )
 }
 
 export default PlayingContainer;

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,59 @@
+#score-wrapper {
+  display: grid;
+  grid-template-columns: 4fr 1fr 4fr;
+  grid-template-rows: 2fr 1fr 2fr;
+  text-align: center;
+}
+
+#p1score {
+  grid-column: 1;
+}
+
+#colon {
+  grid-column: 2;
+}
+
+#p2score {
+  grid-column: 3;
+}
+
+#serve1 {
+  grid-row: 2;
+  grid-column: 1;
+}
+
+#serve2 {
+  grid-row: 2;
+  grid-column: 3;
+}
+
+#p1-display-name {
+  grid-row: 3;
+  grid-column: 1;
+}
+
+#p2-display-name {
+  grid-row: 3;
+  grid-column: 3;
+}
+
+#button-wrapper {
+  display: grid;
+  grid-template-columns: 4fr 1fr 4fr;
+  grid-template-rows: 1fr 1fr;
+  justify-items: center;
+}
+
+#inc-p1 {
+  grid-column-start: 1;
+}
+
+#inc-p2 {
+  grid-column-start: 3;
+}
+
+#undo {
+  grid-column-start: 2;
+  grid-row-start: 2;
+}
+

--- a/server/constants/defaults.js
+++ b/server/constants/defaults.js
@@ -4,8 +4,8 @@ const defaultGameState = {
   gameState: 0,
   p1Score: [0],
   p2Score: [0],
-  serving: null,
-  maxScore: null,
+  serving: 1,
+  maxScore: 21,
   endGameChoice: null
 };
 


### PR DESCRIPTION
## CHANGES

1. PlayingContainer
  * Displays each player's scores, names, and who's currently serving
  * Buttons to increment scores and undo mistakes
2. EndGamecontainer
  * Display winner of game
  * Option buttons for Rematch, Winner Stays, Both Leave

## BONUS
1. Minor fix on server defaults to send maxScore=21 and serving=1 to correctly match default radio selections on client

## TODO
1. Graph on PlayingContainer
2. Sidebar
  * Queue display / Join Queue
  * Ranking
3. Styles